### PR TITLE
6809E updates to support Williams Defender

### DIFF
--- a/libraries/C6809ECpu/C6809ECpu.cpp
+++ b/libraries/C6809ECpu/C6809ECpu.cpp
@@ -265,7 +265,9 @@ C6809ECpu::memoryReadWrite(
     int valueQ;
 
     //
-    // Step 1 - Wait for E-Lo, Q-Lo (E-falling)
+    // Phase 0 - Initial State
+    // - Wait for E-Lo, Q-Lo
+    // - E-falling
     //
     for (int x = 0 ; x < 100 ; x++)
     {
@@ -285,14 +287,17 @@ C6809ECpu::memoryReadWrite(
     CHECK_LITERAL_VALUE_EXIT(error, s_Q_i, valueQ, LOW);
 
     //
-    // Step 2 - Drive RW, A, BA, BS onto the bus.
-    // Set the databus input.
+    // Phase 0 Actions
+    // - Drive RW, A, BA, BS onto the bus.
     //
     m_busA.pinMode(OUTPUT);
     m_busA.digitalWrite(address);
 
     //
-    // If a write, also set a write cycle and drive D.
+    // Driving D on write is due in Phase 1 however
+    // many systems treat Q high time as the active
+    // access time so taking care of D here reduces
+    // the effective cycle time.
     //
     if (readWrite == LOW)
     {
@@ -306,8 +311,9 @@ C6809ECpu::memoryReadWrite(
     interruptsDisabled = true;
 
     //
-    // Step 3 - Wait for E-Lo, Q-Hi (Q rising edge).
-    // E should stay low.
+    // Phase 1
+    // - Wait for E-Lo, Q-Hi
+    // - Q-rising
     //
     for (int x = 0 ; x < 100 ; x++)
     {
@@ -325,8 +331,14 @@ C6809ECpu::memoryReadWrite(
     CHECK_LITERAL_VALUE_EXIT(error, s_Q_i, valueQ, HIGH);
 
     //
-    // Step 4 - Wait for E-Hi, Q-Hi (E-rising)
-    // Nothing to do.
+    // Phase 1 Actions
+    // - On write, drive D (see note above)
+    //
+
+    //
+    // Phase 2
+    // - Wait for E-Hi, Q-Hi
+    // - E-rising
     //
     for (int x = 0 ; x < 100 ; x++)
     {
@@ -344,7 +356,14 @@ C6809ECpu::memoryReadWrite(
     CHECK_PIN_VALUE_EXIT(error, m_pinQ, s_Q_i, HIGH);
 
     //
-    // Step 5 - Wait for E-Hi, Q-Lo (Q-falling)
+    // Phase 2 Actions
+    // - None, currently.
+    //
+
+    //
+    // Phase 3
+    // - Wait for E-Hi, Q-Lo
+    // - Q-falling
     //
     for (int x = 0 ; x < 100 ; x++)
     {
@@ -362,7 +381,8 @@ C6809ECpu::memoryReadWrite(
     CHECK_LITERAL_VALUE_EXIT(error, s_Q_i, valueQ, LOW);
 
     //
-    // Step 6 - D-Read.
+    // Phase 3 Actions
+    // - D read
     //
     if (readWrite == HIGH)
     {
@@ -373,8 +393,9 @@ C6809ECpu::memoryReadWrite(
     }
 
     //
-    // Step 7 - Wait for E-Lo, Q-Lo (E-falling)
-    // Back to initial state.
+    // Phase 0 (Initial State)
+    // - Wait for E-Lo, Q-Lo
+    // - E-falling
     //
     for (int x = 0 ; x < 100 ; x++)
     {
@@ -390,6 +411,11 @@ C6809ECpu::memoryReadWrite(
     }
     CHECK_LITERAL_VALUE_EXIT(error, s_E_i, valueE, LOW);
     CHECK_PIN_VALUE_EXIT(error, m_pinQ, s_Q_i, LOW);
+
+    //
+    // Phase 0 Actions
+    // - On writes, tri-state D
+    //
 
     if (readWrite == LOW)
     {

--- a/libraries/C6809ECpu/C6809ECpu.h
+++ b/libraries/C6809ECpu/C6809ECpu.h
@@ -41,6 +41,7 @@ class C6809ECpu : public ICpu
         //
 
         C6809ECpu(
+            UINT8 QLoToDInClockPulses
         );
 
         // ICpu Interface
@@ -101,6 +102,8 @@ class C6809ECpu : public ICpu
         );
 
     private:
+
+        UINT8         m_QLoToDInClockPulses;
 
         CBus          m_busA;
         CFast8BitBus  m_busD;

--- a/libraries/C6809ECpu/CStarWarsBaseGame.cpp
+++ b/libraries/C6809ECpu/CStarWarsBaseGame.cpp
@@ -162,7 +162,7 @@ CStarWarsBaseGame::CStarWarsBaseGame(
     m_clockPulseCount(0),
     m_lastMatrixProgramAddress(0)
 {
-    m_cpu = new C6809ECpu();
+    m_cpu = new C6809ECpu(0);
     m_cpu->idle();
 
     // A timer is on the INT pin (vector game thus no VBALNK).


### PR DESCRIPTION
Addition of interrupt locks.
Moved the data write to the idle phase to shorten the pulse length of the active phase to better support DRAM.
Addition of aa D read hold off to account for synchronous external timing logic.
