### PR TITLE
Addressing various warnings from arduino IDE 1.8.5 1.8.6 and 1.8.9

### DIFF
--- a/libraries/C6502Cpu/CAstroFighterBaseGame.cpp
+++ b/libraries/C6502Cpu/CAstroFighterBaseGame.cpp
@@ -181,7 +181,7 @@ CAstroFighterBaseGame::~CAstroFighterBaseGame(
 }
 
 
-static PERROR CAstroFighterBaseGame::delayFunction(
+PERROR CAstroFighterBaseGame::delayFunction(
     void *context,
     unsigned long ms
 )

--- a/libraries/InCircuitTester/CFastBus.cpp
+++ b/libraries/InCircuitTester/CFastBus.cpp
@@ -33,11 +33,11 @@ CFastBus::CFastBus(
     m_pinModeSet(false),
     m_currentPinMode(INPUT)
 {
-    m_decodedPinMap            = malloc(m_dataBusSize * sizeof(*m_decodedPinMap));
-    m_physicalPinMask          = malloc(m_dataBusSize * sizeof(*m_physicalPinMask));
-    m_physicalPortRegisterIn   = malloc(m_dataBusSize * sizeof(*m_physicalPortRegisterIn));
-    m_physicalPortRegisterOut  = malloc(m_dataBusSize * sizeof(*m_physicalPortRegisterOut));
-    m_physicalPortRegisterMode = malloc(m_dataBusSize * sizeof(*m_physicalPortRegisterMode));
+    m_decodedPinMap            = (UINT8*)malloc(m_dataBusSize * sizeof(*m_decodedPinMap));
+    m_physicalPinMask          = (UINT8*)malloc(m_dataBusSize * sizeof(*m_physicalPinMask));
+    m_physicalPortRegisterIn   = (volatile UINT8**)malloc(m_dataBusSize * sizeof(*m_physicalPortRegisterIn));
+    m_physicalPortRegisterOut  = (volatile UINT8**)malloc(m_dataBusSize * sizeof(*m_physicalPortRegisterOut));
+    m_physicalPortRegisterMode = (volatile UINT8**)malloc(m_dataBusSize * sizeof(*m_physicalPortRegisterMode));
 
     for (UINT8 i = 0 ; i < m_dataBusSize ; i++)
     {

--- a/libraries/InCircuitTester/CGame.cpp
+++ b/libraries/InCircuitTester/CGame.cpp
@@ -1179,7 +1179,7 @@ void CGame::addAddressOffset(
 
 
 // Default delay function
-static PERROR CGame::delayFunction(
+PERROR CGame::delayFunction(
     void *context,
     unsigned long ms
 )

--- a/libraries/InCircuitTester/Types.h
+++ b/libraries/InCircuitTester/Types.h
@@ -31,8 +31,6 @@
 // System wide definitions
 //
 
-#define NULL ((void*)(0))
-
 #define ARRAYSIZE(x) (sizeof(x)/sizeof(x[0]))
 
 //                     "0123456789ABCDEF"
@@ -208,7 +206,8 @@ typedef struct _ROM_DATA2N {
 //  - 0x1000 bytes (max address 0xFFF) has 12 data samples.
 //
 // ROM Regions support 8-bit & 16-bit data access.
-//
+//
+
 
 typedef struct _ROM_REGION {
 


### PR DESCRIPTION
This pull request addresses a number of warnings from Arduino IDE v1.8.5 to 1.8.9. In the latest IDE version these manifest as a segmentation fault with no warnings.
- Types.h : NULL no longer needs to be redefined. Removing the declaration removes the warning.
- CFastBus.cpp: malloc returns a 'void*' but the left hand variables are 'UINT8*' and 'volatile UINT8**'. A cast addresses this warning. 
- CGame.cpp: declaring 'static' is causing a warning.
- CAstroFighterBaseGame.cpp: declaring 'static' is causing a warning.