### PR TITLE
68000 & 8080: Only set DIR register for lower 1/2 of PORTB

### DIFF
--- a/libraries/C68000Cpu/C68000DedicatedCpu.cpp
+++ b/libraries/C68000Cpu/C68000DedicatedCpu.cpp
@@ -173,7 +173,8 @@ C68000DedicatedCpu::idle(
 
     // Control inputs are always input with no pullup
     *g_portOutControlIn   = s_PORT_BYTE_OFF;
-    *g_dirControlIn       = s_DIR_BYTE_INPUT;
+    *g_dirControlIn       = ~(s_BIT_IN_CLK|s_BIT_IN_VPA|s_BIT_IN_DTACK|s_BIT_IN_BERR);
+    // LabRat: change from s_DIR_BYTE_INPUT as the upper NIBBLE should not be cleared
 
     //
     // Control outputs are always outputs

--- a/libraries/C8080Cpu/C8080DedicatedCpu.cpp
+++ b/libraries/C8080Cpu/C8080DedicatedCpu.cpp
@@ -90,7 +90,8 @@ C8080DedicatedCpu::idle(
     // to give the rising edge a minor boost.
     //
     *g_portOutControlIn  = (s_BIT_IN_CLK1 | s_BIT_IN_CLK2);
-    *g_dirControlIn      = s_DIR_BYTE_INPUT;
+    // LabRat - BugFix: changed to 0xF0 from s_DIR_BYTE_INPUT so that we don't impact the upper nibble
+    *g_dirControlIn      = ~(s_BIT_IN_CLK1 | s_BIT_IN_READY | s_BIT_IN_CLK2 | s_BIT_IN_HOLD); 
 
     // Set address to input with pullup for bus check.
     *g_portOutAddressHi  = s_PORT_BYTE_PULLUP;


### PR DESCRIPTION
C8080 was defaulting ALL of portB to inputs, even though only the lower 4 bits were actually used. For people hacking an LCD onto the higher port pins (while awaiting on the LCD/KEYPAD to arrive), will run into problems. 