### PR TITLE
Add support for Atari Sprint and Sprint 2

### DIFF
--- a/libraries/C6502Cpu/6502GameSelector.h
+++ b/libraries/C6502Cpu/6502GameSelector.h
@@ -28,6 +28,7 @@
 #include <CAstroFighterGame.h>
 #include <CGravitarGame.h>
 #include <CSpaceDuelGame.h>
+#include <CSprintGame.h>
 #include <CTempestGame.h>
 #include <CTomahawk777Game.h>
 #include <CVanguardGame.h>
@@ -52,6 +53,9 @@ static const SELECTOR s_gameSelector[] PROGMEM = {//0123456789abcde
                                                   {"Gravitar (3)   ",  onSelectGame,    (void*) (CGravitarGame::createInstanceGravitarSet3),        false},
                                                   {"Space Duel (1) ",  onSelectGame,    (void*) (CSpaceDuelGame::createInstanceSpaceDuelSet1),      false},
                                                   {"Space Duel (2) ",  onSelectGame,    (void*) (CSpaceDuelGame::createInstanceSpaceDuelSet2),      false},
+                                                  {"Sprint 1       ",  onSelectGame,    (void*) (CSprintGame::createInstanceSprint1),               false},
+                                                  {"Sprint 2 (1)   ",  onSelectGame,    (void*) (CSprintGame::createInstanceSprint2),               false},
+                                                  {"Sprint 2 (2)   ",  onSelectGame,    (void*) (CSprintGame::createInstanceSprint2a),              false},
                                                   {"T-777   (5)    ",  onSelectGame,    (void*) (CTomahawk777Game::createInstanceSet5),             false},
                                                   {"T-777   (5) clk",  onSelectGame,    (void*) (CTomahawk777Game::createInstanceClockMasterSet5),  false},
                                                   {"Tempest (1)    ",  onSelectGame,    (void*) (CTempestGame::createInstanceTempestSet1),          false},

--- a/libraries/C6502Cpu/CSprintBaseGame.cpp
+++ b/libraries/C6502Cpu/CSprintBaseGame.cpp
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2021, Marc Deslauriers
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+// TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include "CSprintBaseGame.h"
+#include "C6502Cpu.h"
+#include <DFR_Key.h>
+
+//
+// Probe Head GND:
+//   6502 GND Pin 1 & GND Pin 21
+//
+
+//
+// RAM region is the same for all versions.
+//
+static const RAM_REGION s_ramRegion[] PROGMEM = { //                                                  "012", "012345"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x01, " F4", "Progrm"}, // "program RAM"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x02, " H4", "Progrm"}, // "program RAM"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x04, " J4", "Progrm"}, // "program RAM"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x08, " K4", "Progrm"}, // "program RAM"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x10, " F3", "Progrm"}, // "program RAM"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x20, " H3", "Progrm"}, // "program RAM"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x40, " J3", "Progrm"}, // "program RAM"
+                                                  {NO_BANK_SWITCH, 0x0400,      0x07FF,      1, 0x80, " K3", "Progrm"}, // "program RAM"
+                                                  {0}
+                                                }; // end of list
+
+//
+// RAM region is the same for all versions.
+// This description is used for the byte-wide intensive random access memory test.
+//
+static const RAM_REGION s_ramRegionByteOnly[] PROGMEM = { //                                        "012", "012345"
+                                                          {NO_BANK_SWITCH, 0x0400, 0x07FF, 1, 0xFF, "RAM", "Progrm"}, // "program RAM"
+                                                          {0}
+                                                        }; // end of list
+
+//
+// No write-only RAM on this platform.
+//
+static const RAM_REGION s_ramRegionWriteOnly[] PROGMEM = { {0} }; // end of list
+
+
+//
+// Output region is the same for all ROM versions.
+//
+static const OUTPUT_REGION s_outputRegion[] PROGMEM = { //                                    "012", "012345"
+                                                        {NO_BANK_SWITCH, 0x0c00, 0xFF, 0x00,  " H8", "ATTTR0"}, // Attract 0
+                                                        {NO_BANK_SWITCH, 0x0c01, 0xFF, 0x00,  " H8", "ATTTR1"}, // Attract 1
+                                                        {NO_BANK_SWITCH, 0x0c10, 0xFF, 0x00,  " H8", "SKID10"}, // Skid1 0
+                                                        {NO_BANK_SWITCH, 0x0c11, 0xFF, 0x00,  " H8", "SKID11"}, // Skid1 1
+                                                        {NO_BANK_SWITCH, 0x0c20, 0xFF, 0x00,  " H8", "SKID20"}, // Skid2 0
+                                                        {NO_BANK_SWITCH, 0x0c21, 0xFF, 0x00,  " H8", "SKID21"}, // Skid2 1
+                                                        {NO_BANK_SWITCH, 0x0c30, 0xFF, 0x00,  " H8", "LAMP10"}, // Lamp1 0
+                                                        {NO_BANK_SWITCH, 0x0c31, 0xFF, 0x00,  " H8", "LAMP11"}, // Lamp1 1
+                                                        {NO_BANK_SWITCH, 0x0c40, 0xFF, 0x00,  " H8", "LAMP20"}, // Lamp2 0
+                                                        {NO_BANK_SWITCH, 0x0c41, 0xFF, 0x00,  " H8", "LAMP21"}, // Lamp2 1
+                                                        {NO_BANK_SWITCH, 0x0c60, 0xFF, 0x00,  " H8", "SPARE0"}, // Spare 0
+                                                        {NO_BANK_SWITCH, 0x0c61, 0xFF, 0x00,  " H8", "SPARE1"}, // Spare 1
+                                                        {NO_BANK_SWITCH, 0x0c80, 0xFF, 0x00,  " E8", "WDRES "}, // watchdog reset
+                                                        {NO_BANK_SWITCH, 0x0d00, 0xFF, 0x00,  " E8", "CL1RST"}, // collision 1 reset
+                                                        {NO_BANK_SWITCH, 0x0d80, 0xFF, 0x00,  " E8", "CL2RST"}, // collision 2 reset
+                                                        {NO_BANK_SWITCH, 0x0e00, 0xFF, 0x00,  " E8", "ST1RST"}, // steering 1 reset
+                                                        {NO_BANK_SWITCH, 0x0e80, 0xFF, 0x00,  " E8", "ST2RST"}, // steering 2 reset
+                                                        {NO_BANK_SWITCH, 0x0f00, 0xFF, 0x00,  " E8", "SNDRST"}, // noise reset
+                                                        {0}
+                                                      }; // end of list
+
+//
+// Custom functions implemented for this game.
+//
+static const CUSTOM_FUNCTION s_customFunction[] PROGMEM = {{NO_CUSTOM_FUNCTION}}; // end of list
+
+CSprintBaseGame::CSprintBaseGame(
+    const ROM_REGION *romRegion,
+    const INPUT_REGION *s_inputRegion
+) : CGame( romRegion,
+           s_ramRegion,
+           s_ramRegionByteOnly,
+           s_ramRegionWriteOnly,
+           s_inputRegion,
+           s_outputRegion,
+           s_customFunction,
+           NO_DELAY_FUNCTION)
+{
+    m_cpu = new C6502Cpu(false);
+
+    m_cpu->idle();
+
+    // VBLANK is on the INT pin (==IRQ0).
+    m_interrupt = ICpu::IRQ0;
+
+    // The interrupt is based on an internal vector
+    m_interruptAutoVector = true;
+
+}
+
+
+CSprintBaseGame::~CSprintBaseGame(
+)
+{
+    delete m_cpu;
+    m_cpu = (ICpu *) NULL;
+}
+
+//
+// TBD
+//
+PERROR
+CSprintBaseGame::interruptCheck(
+)
+{
+    return errorNotImplemented;
+}

--- a/libraries/C6502Cpu/CSprintBaseGame.h
+++ b/libraries/C6502Cpu/CSprintBaseGame.h
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2021, Marc Deslauriers
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+// TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef CSprintBaseGame_h
+#define CSprintBaseGame_h
+
+#include "CGame.h"
+
+
+class CSprintBaseGame : public CGame
+{
+    public:
+
+        //
+        // CSprintBaseGame
+        //
+
+        virtual PERROR interruptCheck(
+        );
+
+    protected:
+
+        CSprintBaseGame(
+            const ROM_REGION *romRegion,
+            const INPUT_REGION *s_inputRegion
+        );
+
+        ~CSprintBaseGame(
+        );
+
+};
+
+#endif
+

--- a/libraries/C6502Cpu/CSprintGame.cpp
+++ b/libraries/C6502Cpu/CSprintGame.cpp
@@ -1,0 +1,157 @@
+//
+// Copyright (c) 2021, Marc Deslauriers
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+// TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include "CSprintGame.h"
+
+
+//                                       01   02   04   08   10   20   40   80  100  200  400  800
+static const UINT16 s_romData2n_1[] = {0x20,0x26,0x20,0xcc,0xcc,0x22,0x12,0x11,0x66,0x66,0x66}; // 6290-01.b1
+static const UINT16 s_romData2n_2[] = {0xcc,0xcc,0xcc,0x44,0x3f,0xfb,0xa2,0xa1,0xa0,0x4a,0x44}; // 6291-01.c1
+static const UINT16 s_romData2n_3[] = {0x8a,0x48,0xa5,0x8d,0xa5,0xc9,0x9a,0xa2,0x38,0xa9,0xff}; // 6442-01.d1
+static const UINT16 s_romData2n_4[] = {0x38,0xa9,0x85,0x08,0x51,0x85,0x09,0x22,0x69,0x10,0x08}; // 6443-01.e1
+static const UINT16 s_romData2n_5[] = {0x8a,0x48,0xa5,0x8d,0xa5,0xc9,0x9a,0xa9,0xd0,0x3d,0x36}; // 6404.d1
+static const UINT16 s_romData2n_6[] = {0x10,0x0a,0x22,0x22,0x10,0xe6,0x3d,0x3d,0xa9,0xe6,0x30}; // 6405.e1
+static const UINT16 s_romData2n_7[] = {0x10,0x0a,0x22,0x22,0x10,0xe6,0x3d,0xbd,0xa9,0xe6,0x30}; // 6405-02.e1
+
+//
+// Sprint1
+//
+static const ROM_REGION s_romRegionSprint1[] PROGMEM = { //
+                                                            {NO_BANK_SWITCH, 0x2000, 0x0800, s_romData2n_1, 0x41fc985e, "A1 "}, // 6290-01.b1
+                                                            {NO_BANK_SWITCH, 0x2800, 0x0800, s_romData2n_2, 0x07f7a920, "C1 "}, // 6291-01.c1
+                                                            {NO_BANK_SWITCH, 0x3000, 0x0800, s_romData2n_3, 0xe9ff0124, "D1 "}, // 6442-01.d1
+                                                            {NO_BANK_SWITCH, 0x3800, 0x0800, s_romData2n_4, 0xd6bb00d0, "E1 "}, // 6443-01.e1
+                                                            {0} }; // end of list
+
+//
+// Sprint2
+//
+static const ROM_REGION s_romRegionSprint2[] PROGMEM = { //
+                                                            {NO_BANK_SWITCH, 0x2000, 0x0800, s_romData2n_1, 0x41fc985e, "A1 "}, // 6290-01.b1
+                                                            {NO_BANK_SWITCH, 0x2800, 0x0800, s_romData2n_2, 0x07f7a920, "C1 "}, // 6291-01.c1
+                                                            {NO_BANK_SWITCH, 0x3000, 0x0800, s_romData2n_5, 0xd2878ff6, "D1 "}, // 6404.d1
+                                                            {NO_BANK_SWITCH, 0x3800, 0x0800, s_romData2n_6, 0x6c991c80, "E1 "}, // 6405.e1
+                                                            {0} }; // end of list
+
+//
+// Sprint2a
+//
+static const ROM_REGION s_romRegionSprint2a[] PROGMEM = { //
+                                                            {NO_BANK_SWITCH, 0x2000, 0x0800, s_romData2n_1, 0x41fc985e, "A1 "}, // 6290-01.b1
+                                                            {NO_BANK_SWITCH, 0x2800, 0x0800, s_romData2n_2, 0x07f7a920, "C1 "}, // 6291-01.c1
+                                                            {NO_BANK_SWITCH, 0x3000, 0x0800, s_romData2n_5, 0xd2878ff6, "D1 "}, // 6404.d1
+                                                            {NO_BANK_SWITCH, 0x3800, 0x0800, s_romData2n_7, 0xe80fd249, "E1 "}, // 6405-02.e1
+                                                            {0} }; // end of list
+
+
+//
+// Input region for Sprint 1
+//
+static const INPUT_REGION s_inputRegionS1[] PROGMEM = { //                              "012", "012345"
+                                                        {NO_BANK_SWITCH, 0x0828, 0x80,  " F9", "GEAR 1"}, // Gear 1
+                                                        {NO_BANK_SWITCH, 0x0829, 0x80,  " F9", "GEAR 2"}, // Gear 2
+                                                        {NO_BANK_SWITCH, 0x082A, 0x80,  " F9", "GEAR 3"}, // Gear 3
+                                                        {NO_BANK_SWITCH, 0x082B, 0x80,  " F9", "GAS   "}, // Gas
+                                                        {NO_BANK_SWITCH, 0x082C, 0x80,  " F9", "SERVIC"}, // Service
+                                                        {NO_BANK_SWITCH, 0x082D, 0x80,  " F9", "P1STRT"}, // Start
+                                                        {NO_BANK_SWITCH, 0x0830, 0x80,  " M9", "DIP 1 "}, // DIP1
+                                                        {NO_BANK_SWITCH, 0x0830, 0x40,  " M9", "DIP 2 "}, // DIP2
+                                                        {NO_BANK_SWITCH, 0x0831, 0x80,  " M9", "DIP 3 "}, // DIP3
+                                                        {NO_BANK_SWITCH, 0x0831, 0x40,  " M9", "DIP 4 "}, // DIP4
+                                                        {NO_BANK_SWITCH, 0x0832, 0x80,  " M9", "DIP 5 "}, // DIP5
+                                                        {NO_BANK_SWITCH, 0x0832, 0x40,  " M9", "DIP 6 "}, // DIP6
+                                                        {NO_BANK_SWITCH, 0x0833, 0x80,  " M9", "DIP 7 "}, // DIP7
+                                                        {NO_BANK_SWITCH, 0x0833, 0x40,  " M9", "DIP 8 "}, // DIP8
+                                                        {NO_BANK_SWITCH, 0x0840, 0x40,  " M8", "COIN 1"}, // Coin 1
+                                                        {NO_BANK_SWITCH, 0x0840, 0x80,  " M8", "COIN 2"}, // Coin 2
+                                                        {NO_BANK_SWITCH, 0x0880, 0xFF,  " M8", "Steer "}, // Steering
+                                                        {NO_BANK_SWITCH, 0x0C00, 0xFF,  " E6", "Sync  "}, // Sync
+                                                        {NO_BANK_SWITCH, 0x1000, 0xFF,  " D2", "Collis"}, // Collision
+                                                        {0}
+                                                      }; // end of list
+
+//
+// Input region for Sprint 2
+//
+static const INPUT_REGION s_inputRegionS2[] PROGMEM = { //                              "012", "012345"
+                                                        {NO_BANK_SWITCH, 0x0818, 0x80,  " F9", "S2P1G1"}, // Sprint 2 P1 Gear 1
+                                                        {NO_BANK_SWITCH, 0x0819, 0x80,  " F9", "S2P2G1"}, // Sprint 2 P2 Gear 1
+                                                        {NO_BANK_SWITCH, 0x081A, 0x80,  " F9", "S2P1G2"}, // Sprint 2 P1 Gear 2
+                                                        {NO_BANK_SWITCH, 0x081B, 0x80,  " F9", "S2P2G2"}, // Sprint 2 P2 Gear 2
+                                                        {NO_BANK_SWITCH, 0x081C, 0x80,  " F9", "S2P1G3"}, // Sprint 2 P1 Gear 3
+                                                        {NO_BANK_SWITCH, 0x081D, 0x80,  " F9", "S2P2G3"}, // Sprint 2 P2 Gear 3
+                                                        {NO_BANK_SWITCH, 0x0828, 0x80,  " F9", "GAS 1 "}, // Gas 1
+                                                        {NO_BANK_SWITCH, 0x0829, 0x80,  " F9", "GAS 2 "}, // Gas 2
+                                                        {NO_BANK_SWITCH, 0x082A, 0x80,  " F9", "SERVIC"}, // Service
+                                                        {NO_BANK_SWITCH, 0x082B, 0x80,  " F9", "P1STRT"}, // P1 Start
+                                                        {NO_BANK_SWITCH, 0x082C, 0x80,  " F9", "P2STRT"}, // P2 Start
+                                                        {NO_BANK_SWITCH, 0x082D, 0x80,  " F9", "TRACKS"}, // Track Select
+                                                        {NO_BANK_SWITCH, 0x0830, 0x80,  " M9", "DIP 1 "}, // DIP1
+                                                        {NO_BANK_SWITCH, 0x0830, 0x40,  " M9", "DIP 2 "}, // DIP2
+                                                        {NO_BANK_SWITCH, 0x0831, 0x80,  " M9", "DIP 3 "}, // DIP3
+                                                        {NO_BANK_SWITCH, 0x0831, 0x40,  " M9", "DIP 4 "}, // DIP4
+                                                        {NO_BANK_SWITCH, 0x0832, 0x80,  " M9", "DIP 5 "}, // DIP5
+                                                        {NO_BANK_SWITCH, 0x0832, 0x40,  " M9", "DIP 6 "}, // DIP6
+                                                        {NO_BANK_SWITCH, 0x0833, 0x80,  " M9", "DIP 7 "}, // DIP7
+                                                        {NO_BANK_SWITCH, 0x0833, 0x40,  " M9", "DIP 8 "}, // DIP8
+                                                        {NO_BANK_SWITCH, 0x0840, 0x40,  " M8", "COIN 1"}, // Coin 1
+                                                        {NO_BANK_SWITCH, 0x0840, 0x80,  " M8", "COIN 2"}, // Coin 2
+                                                        {NO_BANK_SWITCH, 0x0880, 0xFF,  " M8", "Steer1"}, // Steering 1
+                                                        {NO_BANK_SWITCH, 0x08C0, 0xFF,  " M8", "Steer2"}, // Steering 2
+                                                        {NO_BANK_SWITCH, 0x0C00, 0xFF,  " E6", "Sync  "}, // Sync
+                                                        {NO_BANK_SWITCH, 0x1000, 0xFF,  " D2", "Colli1"}, // Collision 1
+                                                        {NO_BANK_SWITCH, 0x1400, 0xFF,  " D2", "Colli2"}, // Collision 2
+                                                        {0}
+                                                      }; // end of list
+
+
+IGame*
+CSprintGame::createInstanceSprint1(
+)
+{
+    return (new CSprintGame(s_romRegionSprint1, s_inputRegionS1));
+}
+
+IGame*
+CSprintGame::createInstanceSprint2(
+)
+{
+    return (new CSprintGame(s_romRegionSprint2, s_inputRegionS2));
+}
+
+IGame*
+CSprintGame::createInstanceSprint2a(
+)
+{
+    return (new CSprintGame(s_romRegionSprint2a, s_inputRegionS2));
+}
+
+CSprintGame::CSprintGame(
+    const ROM_REGION *romRegion,
+    const INPUT_REGION *s_inputRegion
+) : CSprintBaseGame( romRegion, s_inputRegion )
+{
+}
+
+

--- a/libraries/C6502Cpu/CSprintGame.h
+++ b/libraries/C6502Cpu/CSprintGame.h
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2021, Marc Deslauriers
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+// TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#ifndef CSprintGame_h
+#define CSprintGame_h
+
+#include "CSprintBaseGame.h"
+
+class CSprintGame : public CSprintBaseGame
+{
+    public:
+
+        //
+        // Constructors for this game.
+        //
+
+        static IGame* createInstanceSprint1(
+        );
+
+        static IGame* createInstanceSprint2(
+        );
+
+        static IGame* createInstanceSprint2a(
+        );
+
+        //
+        // IGame Interface - wholly implemented in the Base game.
+        //
+
+    private:
+
+        //
+        // Different ROM sets supplied.
+        //
+        CSprintGame(
+            const ROM_REGION *romRegion,
+            const INPUT_REGION *s_inputRegion
+        );
+
+};
+
+#endif
+
+


### PR DESCRIPTION
This adds support for Atari Sprint and Sprint 2.
Tested on a Sprint 2 PCB.